### PR TITLE
解决非标准的gzip压缩

### DIFF
--- a/python/rocketmq/message.py
+++ b/python/rocketmq/message.py
@@ -188,7 +188,7 @@ class MessageView:
             if message.body and message.body[:2] == b'\x1f\x8b':  # Standard Gzip format
                 body = gzip.decompress(message.body)
             else:  # deflate zip
-                body = zlib.decompress(message.body)            
+                body = zlib.decompress(message.body)
         elif body_encoding in [ProtoEncoding.IDENTITY, None]:
             pass
         else:

--- a/python/rocketmq/message.py
+++ b/python/rocketmq/message.py
@@ -17,6 +17,7 @@
 import binascii
 import gzip
 import hashlib
+import zlib
 from typing import Dict, List
 
 from rocketmq.definition import MessageQueue
@@ -184,7 +185,10 @@ class MessageView:
         body_encoding = system_properties.body_encoding
         body = raw
         if body_encoding == ProtoEncoding.GZIP:
-            body = gzip.decompress(message.body)
+            if message.body and message.body[:2] == b'\x1f\x8b':  # Standard Gzip format
+                body = gzip.decompress(message.body)
+            else:  # deflate zip
+                body = zlib.decompress(message.body)            
         elif body_encoding in [ProtoEncoding.IDENTITY, None]:
             pass
         else:


### PR DESCRIPTION
解决非标准的gzip格式
在body_encoding == gzip 时, 使用了deflate压缩, 没有使用标准的gzip压缩, 故做了兼容, 防伪未来服务端修复这个bug
